### PR TITLE
Validate that the year exists when executing the primary_year

### DIFF
--- a/src/bibx/_entities/collection.py
+++ b/src/bibx/_entities/collection.py
@@ -46,7 +46,9 @@ class Collection:
 
         :return: an integer.
         """
-        return min([article.year for article in self.articles])
+        return min(
+            [article.year for article in self.articles if article.year is not None]
+        )
 
     def published_by_year(self) -> Dict[int, int]:
         """

--- a/tests/entities/test_collection.py
+++ b/tests/entities/test_collection.py
@@ -136,6 +136,33 @@ articles = [
         extra={},
         _label=None,
     ),
+    Article(
+        authors=["I"],
+        year=None,
+        title="Ii",
+        journal="Aii",
+        volume="9",
+        page="18",
+        doi="19",
+        references=[],
+        keywords=[],
+        sources=[],
+        extra={},
+        _label=None,
+    ),
+    Article(
+        authors=["I"],
+        title="Ii",
+        journal="Aii",
+        volume="9",
+        page="18",
+        doi="19",
+        references=[],
+        keywords=[],
+        sources=[],
+        extra={},
+        _label=None,
+    ),
 ]
 
 
@@ -165,3 +192,10 @@ def test_cited_by_year():
     assert res.get(2021) == 12
     assert res.get(2022) == 2
     assert res.get(2023) == 0
+
+
+def test_primary_year():
+    collection = Collection(articles=articles)
+
+    res = collection.primary_year
+    assert res == 2000


### PR DESCRIPTION
### Description

Added a validation when applying the `min` function in the `primary_year` method, to make sure that if the `year` does not exist an error does not occur, also added a test for the `primary_year` method that emulates if the `year` is None or does not exist in the `Article`.